### PR TITLE
minor fix to register_contents

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -59,7 +59,7 @@ end
 
 -- Get the contents of the register
 local function register_contents(register_name)
-	return vim.api.nvim_exec(("echo getreg(%q)"):format(register_name), true)
+  return vim.api.nvim_exec(("echo getreg(%q, 1)"):format(register_name), true)
 end
 
 -- Build a map of all the lines


### PR DESCRIPTION
To avoid the contents of the expression register to be called as a
variable.

E.g: The content of my expression register ("=) was `pfile`. Before
adding the 1 to getreg() the registers.nvim mapping was trying to call
it as a (non-existing) variable instead of show the string "pfile".

See `:help getreg()`
