### PR TITLE
feat: unify lua calls into a single command

### DIFF
--- a/plugin/registers.vim
+++ b/plugin/registers.vim
@@ -9,17 +9,22 @@ let s:save_cpo = &cpo
 " Reset them to defaults
 set cpo&vim
 
+" Command completion options
+function! s:arg_opts(A, L, P)
+    return "n\ni\nv"
+endfunction
+
 " Command to run our plugin
-command! Registers lua require'registers'.registers()
+command! -nargs=? -complete=custom,s:arg_opts Registers lua require'registers'.registers(<f-args>)
 
 " Open the popup window when pressing <C-R> in insert mode
-inoremap <silent> <C-R> <C-O><cmd>lua require'registers'.registers('i')<CR>
+inoremap <silent> <C-R> <C-O><cmd>Registers i<CR>
 
 " Open the popup window when pressing " in regular mode
-nnoremap <silent> " <cmd>lua require'registers'.registers('n')<CR>
+nnoremap <silent> " <cmd>Registers n<CR>
 
 " Open the popup window when pressing " in visual mode
-xnoremap <silent> " <esc><cmd>lua require'registers'.registers('v')<CR>
+xnoremap <silent> " <esc><cmd>Registers v<CR>
 
 " Restore after
 let &cpo = s:save_cpo


### PR DESCRIPTION
Unify the calls of lua script into a single command.

This can benefit plugin lazy loading. For vim-plug, one can configure as following:

```vim
Plug 'tversteeg/registers.nvim', { 'on': 'Registers' }
```