### PR TITLE
Fix open augroup for focus lost autocommand.

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -163,6 +163,7 @@ local function open_window()
 	-- Register an autocommand to close window if focus is lost
 	vim.cmd([[augroup registers_focus_lost]])
 	vim.cmd([[autocmd! registers_focus_lost BufLeave <buffer> lua require('registers').close_window()]])
+	vim.cmd([[augroup END]])
 
 	-- Highlight the cursor line
 	vim.api.nvim_win_set_option(win, "cursorline", true)


### PR DESCRIPTION
Just closing off the autogroup. I don't see any need to actually remove the group since it's already namespaced with the plugin name and the autocmd only applies to the floating window anyway. And the autocmd uses `!` so it'll clear any existing autocmds. Collision with user-defined augroups seems pretty unlikely imo, but it could always be given an even more obscure name if need be.