### PR TITLE
Add correct branch to Plug example

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ paq "tversteeg/registers.nvim"
 ### Plug
 
 ```vim
-Plug 'tversteeg/registers.nvim'
+Plug 'tversteeg/registers.nvim', { 'branch': 'main' }
 ```
 
 ### Dein


### PR DESCRIPTION
Hi, vim-plug does not work with the example in the README. It looks for a 'master' branch, but the repository only has a 'main' branch.

Thanks for the awesome plugin!

Hans