### PR TITLE
Add window border option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,5 @@ let g:registers_space_symbol = "." "' ' by default
 let g:registers_register_key_sleep = 1 "0 by default, seconds to wait before closing the window when a register key is pressed
 let g:registers_show_empty_registers = 0 "1 by default, an additional line with the registers without content
 let g:registers_trim_whitespace = 1 "0 by default, don't show whitespace at the begin and end of the registers
+let g:registers_window_border = "single" "'none' by default, can be 'single','double', 'rounded', 'solid', or 'shadow' (requires Neovim 0.5.0+)
 ```

--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -177,6 +177,9 @@ local function open_window()
 		row = opts_row,
 		col = 0
 	}
+   	if vim.api.nvim_call_function("has", {"nvim-0.5"}) == 1 then
+   		opts.border = config().window_border
+   	end
 
 	-- Finally create it with buffer attached
 	win = vim.api.nvim_open_win(buf, true, opts)

--- a/lua/registers/config.lua
+++ b/lua/registers/config.lua
@@ -19,5 +19,6 @@ return function()
 		register_key_sleep = global_var_or("registers_register_key_sleep", 0),
 		show_empty_registers = global_var_or("registers_show_empty_registers", 1),
 		trim_whitespace = global_var_or("registers_trim_whitespace", 0),
+		window_border = global_var_or("registers_window_border", "none"),
 	}
 end


### PR DESCRIPTION
﻿Thanks for the simple and effective plugin! This tiny PR adds optional support for floating window borders, a new-ish feature in Neovim 0.5.0+, to help increase the window's visibility. I agree wholeheartedly with the goal of minimizing visual noise and hope that this keeps it at an acceptable level. 

Regarding the implementation: I found that adding the `border` key to `opts` unconditionally causes older versions of Neovim to throw an error, so we have to check the version before adding the option to the table. 