### PR TITLE
Add window min height option

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,5 @@ let g:registers_register_key_sleep = 1 "0 by default, seconds to wait before clo
 let g:registers_show_empty_registers = 0 "1 by default, an additional line with the registers without content
 let g:registers_trim_whitespace = 1 "0 by default, don't show whitespace at the begin and end of the registers
 let g:registers_window_border = "single" "'none' by default, can be 'single','double', 'rounded', 'solid', or 'shadow' (requires Neovim 0.5.0+)
+let g:registers_window_min_height = 10 "1 by default, a minimal height of the window when there is the cursor at the bottom
 ```

--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -167,6 +167,12 @@ local function open_window()
 		opts_row = win_line - user_scrolloff
 	end
 
+	local min_height = config().window_min_height
+	if win_height < min_height then
+		win_height = min_height
+		opts_row = win_line - min_height
+	end
+
 	-- Set some options
 	local opts = {
 		style = "minimal",

--- a/lua/registers/config.lua
+++ b/lua/registers/config.lua
@@ -20,5 +20,6 @@ return function()
 		show_empty_registers = global_var_or("registers_show_empty_registers", 1),
 		trim_whitespace = global_var_or("registers_trim_whitespace", 0),
 		window_border = global_var_or("registers_window_border", "none"),
+		window_min_height = global_var_or("registers_window_min_height", 1)
 	}
 end


### PR DESCRIPTION
So far, when there was the cursor at the bottom on Neovim, the number of lines shown in the registers window was decided by the `scrolloff` option. Setting a tiny value to it like `scrolloff=2` showed the small window that is hard to see. This PR adds the option that decides the minimal height of the window instead of `scrolloff`.