### PR TITLE
Fix current_buf variable name

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -368,7 +368,7 @@ local function registers(mode)
 
     -- Check if the current buffer is modifiable, otherwise don't open it
     local current_buf = vim.api.nvim_get_current_buf()
-    if vim.api.nvim_buf_get_option(buf, "modifiable") then
+    if vim.api.nvim_buf_get_option(current_buf, "modifiable") then
         open_window()
         set_mappings()
         update_view()


### PR DESCRIPTION
This caused the error below when I had a read-only terminal tab:

E5108: Error executing lua .../.vim/plugged/registers.nvim/lua/registers.lua:371: Invalid buffer id: 147
stack traceback:
        [C]: in function 'nvim_buf_get_option'
        .../.vim/plugged/registers.nvim/lua/registers.lua:371: in function 'registers'
        [string ":lua"]:1: in main chunk
