### PR TITLE
Feed quote if not opening registers window

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -378,6 +378,9 @@ local function registers(mode)
         open_window()
         set_mappings()
         update_view()
+    elseif invocation_mode == "n" then
+        -- Feed quote key after a safety check on invocation_mode
+        vim.fn.feedkeys('"', "n")
     end
 end
 


### PR DESCRIPTION
Without this, register name that comes after "-key is recognised as a
normal mode key by Neovim.

Closes #23.
