### PR TITLE
Add colon to ALL_REGISTERS

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -1,7 +1,7 @@
 local config = require "registers.config"
 
 -- All available registers
-local ALL_REGISTERS = { "*", "+", "\"", "-", "/", "_", "=", "#", "%", ".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z" }
+local ALL_REGISTERS = { "*", "+", "\"", "-", "/", "_", "=", "#", "%", ".", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", ":" }
 
 local buf, win, register_lines, invocation_mode, operator_count, cursor_is_last
 


### PR DESCRIPTION
Without this the colon-register is only available via the arrow keys.