### PR TITLE
add option to transfer register to system clipboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Empty registers are not shown by default.
 
 Use the <kbd>Up</kbd> and <kbd>Down</kbd> or <kbd>Ctrl</kbd><kbd>P</kbd> and <kbd>Ctrl</kbd><kbd>N</kbd> or <kbd>Ctrl</kbd><kbd>J</kbd> and <kbd>Ctrl</kbd><kbd>K</kbd> keys to select the register you want to use and press <kbd>Enter</kbd> to apply it, or type the register you want to apply, which is one of the following:
 
-<kbd>"</kbd> <kbd>0</kbd>-<kbd>9</kbd> <kbd>a</kbd>-<kbd>z</kbd> <kbd>:</kbd> <kbd>.</kbd> <kbd>%</kbd> <kbd>#</kbd> <kbd>=</kbd> <kbd>*</kbd> <kbd>+</kbd> <kbd>_</kbd> <kbd>/</kbd>
+<kbd>"</kbd> <kbd>0</kbd>-<kbd>9</kbd> <kbd>a</kbd>-<kbd>z</kbd> <kbd>:</kbd> <kbd>.</kbd> <kbd>%</kbd> <kbd>#</kbd> <kbd>=</kbd> <kbd>\*</kbd> <kbd>+</kbd> <kbd>\_</kbd> <kbd>/</kbd>
 
 ## Install
 
@@ -289,4 +289,18 @@ Which registers to show and in what order.
 
 ```vim
 let g:registers_show = "*+\""
+```
+
+### `System clipboard`
+
+Transfer selected register to system clipboard.
+
+#### Default
+
+`0`
+
+#### Example
+
+```vim
+let g:system_clip = 1
 ```

--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -313,6 +313,14 @@ local function apply_register(register)
 
 		-- "Press" the key with the register key and paste it if applicable
 		vim.api.nvim_feedkeys(keys, current_mode, true)
+		if config().system_clip == 1 then
+			if vim.fn.has("clipboard") == 1 then
+				vim.cmd('let @*=@'..register)
+			else
+				vim.api.nvim_err_writeln("No clipboard available")
+			end
+		end
+
 	end
 end
 

--- a/lua/registers/config.lua
+++ b/lua/registers/config.lua
@@ -26,5 +26,6 @@ return function()
 		window_max_width = global_var_or("registers_window_max_width", 100),
 		show = global_var_or("registers_show", "*+\"-/_=#%.0123456789abcdefghijklmnopqrstuvwxyz:"),
 		paste_in_normal_mode = global_var_or("registers_paste_in_normal_mode", 0),
+		system_clip = global_var_or("system_clip", 0)
 	}
 end


### PR DESCRIPTION
Thanks for the simple and effective plugin! This tiny PR adds optional support for transferring selected register to system clipboard. 

This may be a niche use, but I sometimes have the need to send registers to the system clipboard. My current method is to open `registers.nvim` to check the registers' keys and then type them in quickly within the timeout, which is a little inconvenient. There is probably an easier way to do this, but this pr simplifies the process and is not turned on by default.