### PR TITLE
fix: registers starting with newline are deemed empty

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -611,8 +611,7 @@ function registers._read_registers()
         local register_info = vim.fn.getreginfo(register)
 
         -- Ignore empty registers
-        if register_info.regcontents and type(register_info.regcontents) == "table" and register_info.regcontents[1] and
-            #register_info.regcontents[1] > 0 then
+        if register_info.regcontents and type(register_info.regcontents) == "table" and register_info.regcontents[1] then
             register_info.register = register
 
             -- The register contents as a single line


### PR DESCRIPTION
If a register is non-empty, but its first character is a newline, it would be erroneously deemed to be empty. I suspect that the condition `#register_info.regcontents[1] > 0` was added with the expectation that if a register were empty, it could appear as a table with a single empty string element, i.e. `{ "" }`. While it is not clear from `:h getreginfo()`, I don't think this is the case, when I type `lua print(vim.fn.getreginfo("a").regcontents)` into the command line when the `a` register has been cleared, the result is `nil`.

Fixes #78

Screenshot:
![2022-10-29T20:20:58,607058750+11:00](https://user-images.githubusercontent.com/11096602/198825613-ad324300-deb3-4f05-8d83-cd0d0936eff8.png)
