### PR TITLE
fix: hiding and trimming multiline registers and double newline on windows

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -702,8 +702,13 @@ function registers._read_registers()
                     line = line:match("^%s*(.-)%s*$")
                 end
 
-                -- Replace newline characters
-                line = line:gsub("[\n\r]", registers.options.symbols.newline)
+                line = line
+                    -- Replace newline characters (win)
+                    :gsub("\r\n", registers.options.symbols.newline)
+                    -- Replace newline characters (unix)
+                    :gsub("\n", registers.options.symbols.newline)
+                    -- Replace newline characters (mac)
+                    :gsub("\r", registers.options.symbols.newline)
                     -- Replace tab characters
                     :gsub("\t", registers.options.symbols.tab)
                     -- Replace space characters

--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -686,7 +686,7 @@ function registers._read_registers()
             register_info.register = register
 
             -- The register contents as a single line
-            local line = table.concat(register_info.regcontents, registers.options.symbols.newline)
+            local line = table.concat(register_info.regcontents, "\n")
             local hide = false
             -- Check whether the register should be hidden due to being empty
             if line and registers.options.hide_only_whitespace then


### PR DESCRIPTION
If the register is multiple lines long and only contains white space, it is not deemed to be "hidden" if the character used to join multiple lines into one is not a white space character. This is the case by default, as it is `⏎ `. Similarly, it is not trimmed.

Also, the pattern used to replace newlines with a special character would replace `"\r\n"` with 2 of the special character. However, on windows, a `"\r\n"` represents only 1 new line.

## Before
The `+` register is 2 newline characters, but it is not hidden when `hide_only_whitespace = true`.
![2022-10-30T12:21:42,739032258+11:00](https://user-images.githubusercontent.com/11096602/198858415-2660cd37-0a88-417e-b603-07453359ea33.png)
![2022-10-30T12:21:55,895233677+11:00](https://user-images.githubusercontent.com/11096602/198858419-fcad77b8-fd4a-4a48-8431-5106c79ff548.png)

## After
It is hidden (which is the same as being `Empty`)
![2022-10-30T12:23:33,870554464+11:00](https://user-images.githubusercontent.com/11096602/198858461-090ba49e-54ab-4979-ad64-8667dcde8275.png)

And when `hide_only_whitespace = false`, it is not hidden.
![2022-10-30T12:26:01,382272013+11:00](https://user-images.githubusercontent.com/11096602/198858489-28b8012f-03ef-4b97-af9f-f7ba4e29de25.png)
