### PR TITLE
fix: Fix an error when using pressing.nvim

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -898,7 +898,7 @@ function registers._bind_global_key(index, key, mode)
         vim.api.nvim_set_keymap(mode, key, "", {
             callback = function()
                 -- Don't open the registers window in a telescope prompt or in a non-modifiable buffer
-                if not vim.bo.modifiable or vim.bo.filetype == "TelescopePrompt" then
+                if not vim.bo.modifiable or vim.bo.filetype == "TelescopePrompt" or vim.bo.filetype == "DressingInput" then
                     return vim.api.nvim_replace_termcodes(key, true, true, true)
                 else
                     -- Call the callback function passed to the options


### PR DESCRIPTION
While using [dressing.nvim](https://github.com/stevearc/dressing.nvim) as vim.input, I get the following error when I press C-R, so I made it exclude the same as Telescope.


```
   Error  06:03:03 PM msg_show.lua_error Error detected while processing CursorMoved Autocommands for "<buffer=6>":
06:03:03 PM msg_show Error executing lua callback: ...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:490: Invalid buffer id: 4
stack traceback:
	[C]: in function 'nvim_buf_clear_namespace'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:490: in function 'cb'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1280: in function 'on_register_highlighted'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1057: in function <...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1047>
   Error  06:03:06 PM msg_show.lua_error Error executing vim.schedule lua callback: ...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:691: Vim(append):Error executing lua callback: ...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:703: Invalid buffer id: 4
stack traceback:
	[C]: in function 'nvim_buf_clear_namespace'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:703: in function <...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:688>
	[C]: in function 'nvim_win_close'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:691: in function '_close_window'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:955: in function '_apply_register'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:415: in function 'cb'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1280: in function 'full_cb'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1296: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
stack traceback:
	[C]: in function 'nvim_win_close'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:691: in function '_close_window'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:955: in function '_apply_register'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:415: in function 'cb'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1280: in function 'full_cb'
	...im/site/pack/packer/opt/registers.nvim/lua/registers.lua:1296: in function ''
	vim/_editor.lua: in function ''
	vim/_editor.lua: in function <vim/_editor.lua:0>
```