### PR TITLE
fix: make clear_highlighted_register changes persists

### DIFF
--- a/lua/registers.lua
+++ b/lua/registers.lua
@@ -517,6 +517,9 @@ function registers.clear_highlighted_register(options)
         -- Clear the register
         vim.fn.setreg(register_info.register, '')
 
+		-- Make the change persistent by writing to shada file
+		vim.cmd("wshada!")
+
         -- Fill the registers again
         registers._read_registers()
 


### PR DESCRIPTION
Fixes #110 

Thanks for the plugin, really enjoying it!!

## The Problem
`vim.fn.setreg(register_info.register, '')`  clears the register value, but only for the session.
Once neovim is restarted, the register content is back to what it was before.

This seemingly is because setting the register value to an empty string does not trigger an update of the shada file. 
Contrarily, setting it to space like `vim.fn.setreg(register_info.register, ' ')` did persist

## Solution
Write to the shada file where register content is stored after `vim.fn.setreg(register_info.register, '')`
